### PR TITLE
Enable scanning media in subfolders

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ The script installs Python dependencies, creates `Channels/Channel1/Shows` and
 `Channels/Channel1/Commercials` as well as `schedules` and `logs`.
 It also offers to copy your media files during setup.
 
+Videos can be organised in subfolders inside the `Shows` or `Commercials`
+directories (e.g. `Shows/Season 1`). The player will automatically search these
+subfolders for media files.
+
 ## Windows
 
 Open PowerShell and execute:

--- a/TVPlayer_Complete copy.py
+++ b/TVPlayer_Complete copy.py
@@ -138,10 +138,19 @@ def probe_duration(path: Path) -> int:
         logging.warning("ffprobe failure (%s) – using dummy duration for %s", e, path)
         return 30_000
 
-def gather_files(dir_: Path, exts=VIDEO_EXTS) -> List[Path]:
+def gather_files(dir_: Path, exts=VIDEO_EXTS, recursive: bool = True) -> List[Path]:
+    """Return media files from *dir_*.
+
+    If *recursive* is True (default) search subdirectories as well. This allows
+    season folders or other groupings inside the Shows/Commercials folders to be
+    detected automatically.
+    """
     if not dir_.exists():
         return []
-    return sorted(f for f in dir_.glob("*") if f.is_file() and f.suffix.lower() in exts)
+    pattern = "**/*" if recursive else "*"
+    return sorted(
+        f for f in dir_.glob(pattern) if f.is_file() and f.suffix.lower() in exts
+    )
 
 def ms_to_hms(ms: int) -> str:
     s = ms // 1000


### PR DESCRIPTION
## Summary
- recursively search for shows and commercials in channel subfolders
- document that media can be organised in subfolders

## Testing
- `python -m py_compile 'TVPlayer_Complete copy.py'`

------
https://chatgpt.com/codex/tasks/task_e_68494bacdd0c8330b9f03e577cb54663