### PR TITLE
Improve schedule updates with loading overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,7 @@ After installation launch the player with:
 ```bash
 python "TVPlayer_Complete copy.py"
 ```
+
+When starting up or reloading schedules the player displays a short loading
+overlay while rebuilding the guide so the listings always match what is
+actually playing.


### PR DESCRIPTION
## Summary
- ensure guide refresh happens with new schedules
- add loading overlay while schedules rebuild
- refresh overlay geometry when window resizes
- document schedule refresh overlay in the README

## Testing
- `python -m py_compile "TVPlayer_Complete copy.py"`

------
https://chatgpt.com/codex/tasks/task_e_68495104e1f8833099a34b80c39e836d