### PR TITLE
Enable location-based weather and add per-channel ad toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ buttons let you move the on-screen focus without using a mouse and the new
 The TV guide now includes a small panel in the top-right corner showing the
 current system time and local weather when internet access is available. Click
 the panel or the `refresh` link to update the information or view the day's
-forecast.
+forecast. Use the **Settings** menu to set your preferred weather location.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- set default weather location to Norfolk
- add Weather section in preferences dialog
- fetch weather data using the configured location
- add checkable `Use All Commercials` action in guide context menu
- document setting weather location in README

## Testing
- `python -m py_compile 'TVPlayer_Complete copy.py'`

------
https://chatgpt.com/codex/tasks/task_e_6849e958036083308d3ecd859fc4d37a