### PR TITLE
Fix theme CSS placeholders

### DIFF
--- a/TVPlayer_Complete copy.py
+++ b/TVPlayer_Complete copy.py
@@ -3491,12 +3491,12 @@ class TVPlayer(QMainWindow):
         self.info = QLabel("", self)
         self.info.setStyleSheet(self.css(f"""
             font-size: {self.base_info_font_size}px;
-            color: {fg};
+            color: {{fg}};
             background: rgba(0,0,0,220);
             padding: 12px;
             border-radius: 8px;
-            border: 2px solid {fg};
-            font-family: "{font}", monospace;
+            border: 2px solid {{fg}};
+            font-family: "{{font}}", monospace;
         """))
         self.info.hide()
 
@@ -3519,12 +3519,12 @@ class TVPlayer(QMainWindow):
         size = int(self.base_info_font_size * scale)
         self.info.setStyleSheet(self.css(f"""
             font-size: {size}px;
-            color: {fg};
+            color: {{fg}};
             background: rgba(0,0,0,220);
             padding: 12px;
             border-radius: 8px;
-            border: 2px solid {fg};
-            font-family: "{font}", monospace;
+            border: 2px solid {{fg}};
+            font-family: "{{font}}", monospace;
         """))
 
     # ── ENHANCED WEB SERVER METHODS ──────────────────────────────────


### PR DESCRIPTION
## Summary
- escape placeholders used by css formatter so Pylance and Python don't complain

## Testing
- `python -m py_compile "TVPlayer_Complete copy.py"`


------
https://chatgpt.com/codex/tasks/task_e_684c3652cf9483308e5ccaf0c85a3f12