### PR TITLE
Fix menu stylesheet formatting for theme application

### DIFF
--- a/TVPlayer_Complete copy.py
+++ b/TVPlayer_Complete copy.py
@@ -4891,29 +4891,29 @@ class TVPlayer(QMainWindow):
         
         # Apply theme to menu
         menubar.setStyleSheet(self.css("""
-            QMenuBar {
+            QMenuBar {{
                 background-color: {bg};
                 color: {fg};
                 border-bottom: 2px solid {fg};
-            }
-            QMenuBar::item {
+            }}
+            QMenuBar::item {{
                 padding: 4px 10px;
                 background: transparent;
-            }
-            QMenuBar::item:selected {
+            }}
+            QMenuBar::item:selected {{
                 background: {hover};
-            }
-            QMenu {
+            }}
+            QMenu {{
                 background-color: {alt};
                 color: {fg};
                 border: 2px solid {fg};
-            }
-            QMenu::item {
+            }}
+            QMenu::item {{
                 padding: 4px 20px;
-            }
-            QMenu::item:selected {
+            }}
+            QMenu::item:selected {{
                 background-color: {hover};
-            }
+            }}
         """))
         
         # Channel Menu


### PR DESCRIPTION
## Summary
- escape literal braces in the menu stylesheet to avoid `KeyError`

## Testing
- `python -m py_compile 'TVPlayer_Complete copy.py'`

------
https://chatgpt.com/codex/tasks/task_e_684c390b3bb483308e829f2ad4506024