### PR TITLE
Fix early menu build

### DIFF
--- a/TVPlayer_Complete copy.py
+++ b/TVPlayer_Complete copy.py
@@ -3504,7 +3504,8 @@ class TVPlayer(QMainWindow):
                 " padding: 20px; border-radius: 8px; border: 2px solid {fg};"
                 " font-weight: bold;"
             ))
-        if hasattr(self, '_build_menu'):
+        # Rebuild the menu only after the main UI components exist.
+        if hasattr(self, 'guide'):
             self._build_menu()
     def css(self, template: str) -> str:
         """Format a stylesheet string using the current theme."""


### PR DESCRIPTION
## Summary
- avoid calling `_build_menu` before `self.guide` exists

## Testing
- `python -m py_compile "TVPlayer_Complete copy.py"`


------
https://chatgpt.com/codex/tasks/task_e_684d706336f88330be55e03577862ba9