### PR TITLE
Improve network sharing UI

### DIFF
--- a/TVPlayer_Complete copy.py
+++ b/TVPlayer_Complete copy.py
@@ -4690,6 +4690,10 @@ class TVPlayer(QMainWindow):
             act.triggered.connect(partial(self._tray_switch_channel, idx))
 
         self._tray_menu.addSeparator()
+        self._tray_menu.addAction("[RS] Reload Schedule", lambda checked=False: self.reload_schedule())
+        self._tray_menu.addAction("[RESTART] Restart Web Server", lambda checked=False: self.restart_web_server())
+        self._tray_menu.addAction("[SHARE] Share Network", lambda checked=False: self.show_share_network())
+        self._tray_menu.addSeparator()
         self._tray_menu.addAction("[MUTE] Mute/Unmute", lambda checked=False: self.mute())
         self._tray_menu.addSeparator()
         self._tray_menu.addAction("[PREF] Preferences...", lambda checked=False: self.show_settings())
@@ -5184,10 +5188,10 @@ class TVPlayer(QMainWindow):
         self._populate_recent_menu()
         file_menu.addAction("[SAVED] Manage Saved Folders", self.show_saved_channels_editor)
         file_menu.addSeparator()
+        file_menu.addAction("[SHARE] Share Network", self.show_share_network)
         file_menu.addAction("[EDIT] &TV Network Editor", self.show_network_editor, "Ctrl+E")
         file_menu.addAction("[RELOAD] &Reload Channels", self.reload_channels, "F5")
         file_menu.addSeparator()
-        file_menu.addAction("[QR] &Remote QR Code...", self.show_qr_code)
         file_menu.addAction("[EXIT] E&xit", self.close, "Ctrl+Q")
         
         # Audio/Video Menu
@@ -5444,8 +5448,8 @@ class TVPlayer(QMainWindow):
         dlg = SavedChannelsDialog(self)
         dlg.exec_()
 
-    def show_qr_code(self):
-        """Show QR code generator dialog for the web remote."""
+    def show_share_network(self):
+        """Display a QR code for the current remote URL."""
         url = self.flask_manager.remote_url or f"http://{self.flask_manager.main_ip or 'localhost'}:{self.settings.get('web_port', 5050)}"
         dlg = QRCodeDialog(url, self)
         dlg.exec_()

--- a/qr_code_dialog.py
+++ b/qr_code_dialog.py
@@ -1,127 +1,32 @@
-from __future__ import annotations
-import os
-
-from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import QDialog, QVBoxLayout, QLabel, QPushButton, QFileDialog
 from PyQt5.QtGui import QPixmap
-from PyQt5.QtWidgets import (
-    QDialog, QLabel, QLineEdit, QComboBox, QSpinBox, QPushButton,
-    QVBoxLayout, QHBoxLayout, QFormLayout, QFileDialog, QMessageBox
-)
-
 import qrcode
-from PIL.ImageQt import ImageQt
+from io import BytesIO
 
 
 class QRCodeDialog(QDialog):
-    """Simple QR code generator dialog."""
+    """Display a QR code for sharing the remote URL."""
 
-    def __init__(self, data: str = "", parent=None):
+    def __init__(self, data, parent=None):
         super().__init__(parent)
-        self.setWindowTitle("[QR] Remote QR Code")
-        self.setModal(True)
-        self.setFixedSize(320, 420)
+        self.setWindowTitle("[WEB] Remote QR")
+        buf = BytesIO()
+        qrcode.make(data).save(buf, format="PNG")
+        buf.seek(0)
+        pix = QPixmap()
+        pix.loadFromData(buf.read(), "PNG")
 
-        if parent and hasattr(parent, "css"):
-            self.setStyleSheet(parent.css("""
-                QDialog {{ background-color: {bg}; color: {fg}; }}
-                QLabel {{ color: {fg}; }}
-                QLineEdit, QComboBox, QSpinBox {{
-                    background-color: {alt};
-                    color: {fg};
-                    border: 1px solid {fg};
-                }}
-                QPushButton {{
-                    background-color: {alt};
-                    color: {fg};
-                    border: 2px solid {fg};
-                    padding: 6px 12px;
-                    font-weight: bold;
-                    border-radius: 4px;
-                }}
-                QPushButton:hover {{ background-color: {hover}; }}
-            """))
+        v = QVBoxLayout(self)
+        v.addWidget(QLabel(f"<b>{data}</b>"))
+        img = QLabel()
+        img.setPixmap(pix)
+        v.addWidget(img)
 
-        self.qr_img = None
+        save = QPushButton("Save PNG…")
+        save.clicked.connect(lambda: self._save_png(pix))
+        v.addWidget(save)
 
-        self.data_edit = QLineEdit(data)
-        self.ec_combo = QComboBox()
-        self.ec_combo.addItems(["L", "M", "Q", "H"])
-        self.size_combo = QComboBox()
-        self.size_combo.addItems(["Small", "Medium", "Large"])
-        self.border_spin = QSpinBox()
-        self.border_spin.setRange(0, 10)
-        self.border_spin.setValue(4)
-
-        form = QFormLayout()
-        form.addRow("Data:", self.data_edit)
-        form.addRow("Error correction:", self.ec_combo)
-        form.addRow("Size:", self.size_combo)
-        form.addRow("Border:", self.border_spin)
-
-        self.preview = QLabel()
-        self.preview.setAlignment(Qt.AlignCenter)
-
-        gen_btn = QPushButton("[GEN] Generate")
-        gen_btn.clicked.connect(self.generate_qr)
-        save_btn = QPushButton("[SAVE] Save PNG…")
-        save_btn.clicked.connect(self.save_png)
-
-        btn_row = QHBoxLayout()
-        btn_row.addWidget(gen_btn)
-        btn_row.addWidget(save_btn)
-
-        layout = QVBoxLayout(self)
-        layout.addLayout(form)
-        layout.addWidget(self.preview, 1)
-        layout.addLayout(btn_row)
-
-        # Generate initial QR if data provided
-        if data:
-            self.generate_qr()
-
-    # ------------------------------------------------------
-    def _box_size(self) -> int:
-        mapping = {"Small": 5, "Medium": 10, "Large": 15}
-        return mapping.get(self.size_combo.currentText(), 10)
-
-    def generate_qr(self):
-        data = self.data_edit.text().strip()
-        if not data:
-            QMessageBox.information(self, "No data", "Please enter something to encode.")
-            return
-        ec_map = {
-            "L": qrcode.constants.ERROR_CORRECT_L,
-            "M": qrcode.constants.ERROR_CORRECT_M,
-            "Q": qrcode.constants.ERROR_CORRECT_Q,
-            "H": qrcode.constants.ERROR_CORRECT_H,
-        }
-        try:
-            qr = qrcode.QRCode(
-                error_correction=ec_map[self.ec_combo.currentText()],
-                box_size=self._box_size(),
-                border=self.border_spin.value(),
-            )
-            qr.add_data(data)
-            qr.make(fit=True)
-            img = qr.make_image(fill_color="black", back_color="white").convert("RGB")
-            self.qr_img = img
-            qimg = ImageQt(img)
-            pix = QPixmap.fromImage(qimg)
-            self.preview.setPixmap(pix)
-            self.preview.setFixedSize(pix.size())
-        except Exception as exc:
-            QMessageBox.warning(self, "QR generation failed", str(exc))
-
-    def save_png(self):
-        if self.qr_img is None:
-            QMessageBox.information(self, "Nothing to save", "Generate a QR code first.")
-            return
-        path, _ = QFileDialog.getSaveFileName(self, "Save QR code", "qr.png", "PNG images (*.png)")
-        if not path:
-            return
-        try:
-            os.makedirs(os.path.dirname(path), exist_ok=True)
-            self.qr_img.save(path)
-            QMessageBox.information(self, "Saved", f"QR code saved to:\n{path}")
-        except Exception as exc:
-            QMessageBox.warning(self, "Save failed", str(exc))
+    def _save_png(self, pix):
+        path, _ = QFileDialog.getSaveFileName(self, "Save QR", "", "PNG (*.png)")
+        if path:
+            pix.save(path, "PNG")


### PR DESCRIPTION
## Summary
- simplify QR code dialog to only display and save a PNG
- add **Share Network** action to File menu using new dialog
- reorganize tray menu with restart and reload options

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_684eed718670833094a0b92c19d5cf80