### PR TITLE
Improve QR imports, add program restart and robust schedule reload

### DIFF
--- a/qr_code_dialog.py
+++ b/qr_code_dialog.py
@@ -1,4 +1,10 @@
-from PyQt5.QtWidgets import QDialog, QVBoxLayout, QLabel, QPushButton, QFileDialog
+from PyQt5.QtWidgets import (
+    QDialog,
+    QVBoxLayout,
+    QLabel,
+    QPushButton,
+    QFileDialog,
+)
 from PyQt5.QtGui import QPixmap
 import qrcode
 from io import BytesIO


### PR DESCRIPTION
## Summary
- clean up QR code dialog imports
- add program restart controls and refresh guide when server restarts
- ensure schedule reload returns to guide
- avoid repeating first two hours of schedule when rebuilding

## Testing
- `python -m py_compile 'TVPlayer_Complete copy.py' qr_code_dialog.py`

------
https://chatgpt.com/codex/tasks/task_e_6854f55848588330b73162d3b2535d90