### PR TITLE
Refactor installers to use venv and add tests

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -2,25 +2,29 @@ Write-Host "=== TVPlayer Installer (Windows) ==="
 $green = "`e[32m"
 $reset = "`e[0m"
 
-# Check for Python
+# Ensure Python
 $python = Get-Command python -ErrorAction SilentlyContinue
 if (-not $python) {
     Write-Host "Python is required. Please install Python 3 and ensure 'python' is in PATH."
     exit 1
 }
 
-# Ensure pip is available
-$pip = Get-Command pip -ErrorAction SilentlyContinue
-if (-not $pip) {
-    Write-Host "pip not found. Attempting to bootstrap via ensurepip..."
-    python -m ensurepip --default-pip
+$root = Split-Path -Parent $MyInvocation.MyCommand.Path
+$venvPath = Join-Path $root 'venv'
+if (-not (Test-Path $venvPath)) {
+    python -m venv $venvPath
+}
+$venvPython = Join-Path $venvPath 'Scripts\python.exe'
+
+if (-not $env:SKIP_PIP) {
+    Write-Host "Installing Python packages..."
+    & $venvPython -m pip install -r (Join-Path $root 'requirements.txt')
+    $pkgOk = $?
+} else {
+    Write-Host "Skipping Python package installation"
+    $pkgOk = $true
 }
 
-Write-Host "Installing Python packages (PyQt5, Flask, psutil, requests)..."
-pip install -r requirements.txt
-$pkgOk = $?
-
-$root = Split-Path -Parent $MyInvocation.MyCommand.Path
 $channels = Join-Path $root 'Channels'
 $shows = Join-Path $channels 'Channel1\Shows'
 $commercials = Join-Path $channels 'Channel1\Commercials'
@@ -43,10 +47,21 @@ if ($src) {
 }
 $copyOk = $true
 
+$desktop = [Environment]::GetFolderPath('Desktop')
+$shortcut = Join-Path $desktop 'TVPlayer.lnk'
+$wsh = New-Object -ComObject WScript.Shell
+$sc = $wsh.CreateShortcut($shortcut)
+$sc.TargetPath = $venvPython
+$sc.Arguments = "`"$($root)\TVPlayer_Complete copy.py`""
+$sc.WorkingDirectory = $root
+$iconPath = Join-Path $root 'logo.png'
+if (Test-Path $iconPath) { $sc.IconLocation = $iconPath }
+$sc.Save()
+
 Write-Host ""
 if ($pkgOk) { Write-Host "$green[✓] Python packages installed$reset" }
 if ($dirOk) { Write-Host "$green[✓] Folder structure created$reset" }
 if ($copyOk) { Write-Host "$green[✓] Media setup complete$reset" }
-Write-Host "$green[✓] Installation complete. Run: python 'TVPlayer_Complete copy.py'$reset"
+Write-Host "$green[✓] Installation complete. Run: `$venvPython `"$root\TVPlayer_Complete copy.py`"$reset"
 Write-Host "If a logo.png file exists in this folder it will become the"
 Write-Host "system tray icon when running Infinite Tv."

--- a/install.sh
+++ b/install.sh
@@ -5,22 +5,29 @@ GREEN="\e[32m"
 RESET="\e[0m"
 echo "=== TVPlayer Installer (Linux) ==="
 
-# Check for Python 3
+# Ensure Python 3 is available
 if ! command -v python3 >/dev/null; then
     echo "Python 3 is required. Please install Python 3 and re-run this script."
     exit 1
 fi
 
-# Check for pip
-if ! command -v pip3 >/dev/null; then
-    echo "pip3 not found. Attempting to install..."
-    if command -v apt-get >/dev/null; then
-        sudo apt-get update
-        sudo apt-get install -y python3-pip
+# Create virtual environment
+if [ ! -d "venv" ]; then
+    python3 -m venv venv
+fi
+source venv/bin/activate
+
+# Install Python packages
+if [ -z "$SKIP_PIP" ]; then
+    echo "Installing Python packages..."
+    if pip install -r requirements.txt; then
+        pkg_ok=true
     else
-        echo "Please install pip for Python 3 manually."
-        exit 1
+        pkg_ok=false
     fi
+else
+    echo "Skipping Python package installation"
+    pkg_ok=true
 fi
 
 # Optional: install ffmpeg if missing
@@ -32,13 +39,6 @@ if ! command -v ffprobe >/dev/null; then
             sudo apt-get install -y ffmpeg
         fi
     fi
-fi
-
-echo "Installing Python packages (PyQt5, Flask, psutil, requests)..."
-if pip3 install --user -r requirements.txt; then
-    pkg_ok=true
-else
-    pkg_ok=false
 fi
 
 CHANNELS_DIR="$(pwd)/Channels"
@@ -53,10 +53,22 @@ if [ -n "$mpath" ] && [ -d "$mpath" ]; then
 fi
 copy_ok=true
 
-echo
+DESKTOP_DIR="${HOME}/Desktop"
+mkdir -p "$DESKTOP_DIR"
+cat > "$DESKTOP_DIR/TVPlayer.desktop" <<EOF
+[Desktop Entry]
+Type=Application
+Name=TVPlayer
+Exec=$(pwd)/venv/bin/python "$(pwd)/TVPlayer_Complete copy.py"
+Path=$(pwd)
+Icon=$(pwd)/logo.png
+Terminal=false
+EOF
+chmod +x "$DESKTOP_DIR/TVPlayer.desktop"
+
 if [ "$pkg_ok" = true ]; then echo -e "${GREEN}[✓] Python packages installed${RESET}"; fi
 if [ "$dir_ok" = true ]; then echo -e "${GREEN}[✓] Folder structure created${RESET}"; fi
 if [ "$copy_ok" = true ]; then echo -e "${GREEN}[✓] Media setup complete${RESET}"; fi
-echo -e "${GREEN}[✓] Installation complete. Run with: python3 'TVPlayer_Complete copy.py'${RESET}"
+echo -e "${GREEN}[✓] Installation complete. Run with: $(pwd)/venv/bin/python 'TVPlayer_Complete copy.py'${RESET}"
 echo "If you have a logo.png file in this directory it will be used for the"
 echo "system tray icon on supported desktops."

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -1,0 +1,7 @@
+import subprocess, sys
+
+FILES = ['TVPlayer_Complete copy.py', 'qr_code_dialog.py']
+
+def test_python_files_compile():
+    for f in FILES:
+        subprocess.check_call([sys.executable, '-m', 'py_compile', f])

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -1,0 +1,36 @@
+import os
+import subprocess
+import sys
+import shutil
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_install_sh_creates_venv_and_desktop(tmp_path):
+    # copy required files to temp working directory
+    work = tmp_path / 'work'
+    work.mkdir()
+    for fname in ['install.sh', 'requirements.txt', 'TVPlayer_Complete copy.py']:
+        shutil.copy(ROOT / fname, work / fname)
+
+    home = tmp_path / 'home'
+    desktop = home / 'Desktop'
+    desktop.mkdir(parents=True)
+
+    env = os.environ.copy()
+    env['HOME'] = str(home)
+    env['SKIP_PIP'] = '1'
+
+    # run installer with blank answers to prompts
+    subprocess.run(['bash', 'install.sh'], cwd=work, env=env, input='\n\n', text=True, check=True)
+
+    assert (work / 'venv').exists()
+    assert (work / 'Channels').exists()
+    assert (desktop / 'TVPlayer.desktop').exists()
+
+
+def test_install_ps1_contains_venv_and_shortcut():
+    content = (ROOT / 'install.ps1').read_text()
+    assert 'python -m venv' in content
+    assert 'CreateShortcut' in content


### PR DESCRIPTION
## Summary
- Refactor Linux and Windows installers to create a virtual environment, install requirements, and add desktop shortcuts
- Add tests validating Python files compile and installer scripts create expected files

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893d5f7f2ac83308af2c37ec0f74604