### PR TITLE
Add Pillow dependency for QR code image generation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 PyQt5
 Flask
-psutil
 requests
+psutil
 qrcode
+Pillow


### PR DESCRIPTION
## Summary
- include Pillow in requirements so qrcode can produce images
- keep dependency versions unpinned for venv-friendly installs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba61ad40f483309aa64d737df59de2