### PR TITLE
Add QR helper and Steam Deck setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,41 @@ On Linux install these via your package manager. On Windows download the
 latest releases from their official websites and check the option to add
 Python and Git to your system `PATH`.
 
+## Steam Deck (Desktop Mode)
+
+Prereqs: Python 3 (preinstalled), network, your media files.
+
+Install (one shot):
+
+```bash
+cd ~/Desktop/TVPlayer   # or wherever you extracted
+chmod +x install_steamdeck.sh
+./install_steamdeck.sh
+```
+
+Launch: double-click **TVPlayer (Infinite TV)** on Desktop, or `./run.sh`.
+
+If video won't play: install system codecs (ffmpeg, GStreamer good/bad/ugly/libav) via Discover or Konsole commands:
+
+```bash
+sudo pacman -S ffmpeg
+sudo pacman -S gstreamer gst-plugins-good
+sudo pacman -S gst-plugins-bad gst-plugins-ugly
+sudo pacman -S gst-libav
+```
+
+Logs: see `logs/errors.log` for crashes.
+
+Media folders: add files to `Channels/Channel1/Shows` to start.
+
+**Gaming Mode (optional):**
+
+Add `run.sh` as a Non-Steam Game.
+
+In Launch Options, set: `QT_QPA_PLATFORM=xcb %command%`
+
+UI/tray is best in Desktop Mode.
+
 ## Linux Install
 
 Run the installer from a terminal:

--- a/qr_utils.py
+++ b/qr_utils.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+import qrcode
+
+APP_ROOT = Path(__file__).resolve().parent
+TMP_DIR = APP_ROOT / "tmp"
+
+
+def make_qr_png(text: str, out_path: Path) -> None:
+    """Generate a QR code PNG containing *text* and save to *out_path*.
+
+    The parent directory of *out_path* is created automatically. By
+    convention, place outputs inside :data:`TMP_DIR`.
+    """
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    img = qrcode.make(text)  # uses Pillow under the hood
+    img.save(str(out_path))
+

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -1,6 +1,6 @@
 import subprocess, sys
 
-FILES = ['tv.py', 'qr_code_dialog.py']
+FILES = ['tv.py', 'qr_code_dialog.py', 'qr_utils.py']
 
 def test_python_files_compile():
     for f in FILES:

--- a/tests/test_qr_utils.py
+++ b/tests/test_qr_utils.py
@@ -1,0 +1,16 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from qr_utils import TMP_DIR, make_qr_png
+
+
+def test_make_qr_png_creates_file():
+    out = TMP_DIR / "test_qr.png"
+    if out.exists():
+        out.unlink()
+    make_qr_png("hello", out)
+    assert out.exists()
+    out.unlink()


### PR DESCRIPTION
## Summary
- add `make_qr_png` helper to generate and save QR code PNGs
- document Steam Deck Desktop Mode setup and optional Gaming Mode tweak
- test QR helper and compile it with the rest of the project

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68baa91d81b88330960a303dae3befc1