### PR TITLE
Improve PyQt video compatibility on Steam Deck

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -2,9 +2,27 @@
 set -euo pipefail
 
 export QT_QPA_PLATFORM=xcb
+if [[ "${XDG_SESSION_TYPE:-}" == "wayland" ]]; then
+  echo "Warning: XDG_SESSION_TYPE=wayland detected; forcing QT_QPA_PLATFORM=xcb" >&2
+fi
 export QT_MEDIA_BACKEND=gstreamer
 export GST_PLUGIN_FEATURE_RANK=vaapidecodebin:PRIMARY,vaapidecode:PRIMARY
+
+GST_LIB_PATHS=(/usr/lib/x86_64-linux-gnu/gstreamer-1.0 /usr/lib/gstreamer-1.0)
+for dir in "${GST_LIB_PATHS[@]}"; do
+  if [[ -d "$dir" && ":${LD_LIBRARY_PATH:-}:" != *":$dir:"* ]]; then
+    LD_LIBRARY_PATH="${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$dir"
+  fi
+done
+export LD_LIBRARY_PATH
+
 export PYTHONUNBUFFERED=1
+
+echo "Environment:"
+echo "  QT_QPA_PLATFORM=$QT_QPA_PLATFORM"
+echo "  QT_MEDIA_BACKEND=$QT_MEDIA_BACKEND"
+echo "  GST_PLUGIN_FEATURE_RANK=$GST_PLUGIN_FEATURE_RANK"
+echo "  LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 


### PR DESCRIPTION
## Summary
- Force xcb platform and gstreamer media backend for PyQt
- Add VAAPI plugin preference and system GStreamer paths
- Warn when Wayland session detected and echo effective environment

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbd15fc31883309e740c8a13121289