### PR TITLE
Add QMediaPlayer diagnostics and path helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@ On Linux install these via your package manager. On Windows download the
 latest releases from their official websites and check the option to add
 Python and Git to your system `PATH`.
 
+## Steam Deck Quick Start
+
+```bash
+./deck_repair.sh
+./run.sh    # or launch via desktop entry
+```
+
+This installs required Python packages and launches the player with sensible
+defaults for the Deck.
+
 ## Steam Deck (Desktop Mode)
 
 Prereqs: Python 3 (preinstalled), network, your media files.
@@ -144,6 +154,20 @@ bash install.sh     # or install.ps1 on Windows
 Your existing channel folders and configuration files will be preserved.
 
 ## Troubleshooting
+
+Basic GStreamer test:
+
+```bash
+gst-play-1.0 path/to/video.mp4
+```
+
+If that plays but the app does not, ensure Qt uses X11:
+
+```bash
+export QT_QPA_PLATFORM=xcb
+```
+
+Logs can be found in `logs/errors.log` and `logs/qtmultimedia.log`.
 
 Ensure Python 3 and pip are installed and available in your `PATH`. If the
 installers fail to download packages because your system lacks internet

--- a/media_diagnostics.py
+++ b/media_diagnostics.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+import logging
+from pathlib import Path
+from PyQt5.QtMultimedia import QMediaPlayer
+
+APP_ROOT = Path(__file__).resolve().parent
+LOG_DIR = APP_ROOT / "logs"
+LOG_DIR.mkdir(parents=True, exist_ok=True)
+
+class MediaDiagnostics:
+    """Mixin providing verbose QMediaPlayer diagnostics."""
+    def __init__(self) -> None:
+        self._md_logger = logging.getLogger("qtmultimedia")
+        if not self._md_logger.handlers:
+            handler = logging.FileHandler(LOG_DIR / "qtmultimedia.log")
+            handler.setFormatter(logging.Formatter("%(asctime)s [%(levelname)s] %(message)s"))
+            self._md_logger.addHandler(handler)
+            self._md_logger.setLevel(logging.INFO)
+        try:
+            types = QMediaPlayer().supportedMimeTypes()
+            self._md_logger.info("Supported MIME types: %s", ", ".join(types))
+            if "video/mp4" not in types and "video/h264" not in types:
+                self._md_logger.warning("Missing 'video/mp4' or 'video/h264' support")
+        except Exception as e:  # pragma: no cover - diagnostics only
+            self._md_logger.error(f"supportedMimeTypes preflight failed: {e}")
+
+    def init_media_diagnostics(self, player: QMediaPlayer) -> None:
+        """Connect diagnostics to a QMediaPlayer instance."""
+        self._diag_player = player
+        if hasattr(player, "errorOccurred"):
+            player.errorOccurred.connect(self._on_media_error)
+        elif hasattr(player, "error"):
+            player.error.connect(self._on_media_error)
+        if hasattr(player, "errorChanged"):
+            player.errorChanged.connect(self._on_media_error)
+        player.mediaStatusChanged.connect(self._on_media_status)
+
+    # ------------------------------------------------------------------
+    def _on_media_status(self, status):  # pragma: no cover - runtime info
+        self._md_logger.info("media status changed: %s", int(status))
+
+    def _on_media_error(self, *args):  # pragma: no cover - runtime info
+        code = getattr(self._diag_player, "error", lambda: None)()
+        msg = getattr(self._diag_player, "errorString", lambda: "")()
+        self._md_logger.error("media error %s: %s", code, msg)
+        if hasattr(self, "_osd"):
+            self._osd("Media error. Missing GStreamer plugins or Wayland backend in use")


### PR DESCRIPTION
## Summary
- Add `MediaDiagnostics` mixin to log QMediaPlayer errors and statuses to `logs/qtmultimedia.log` with startup codec preflight
- Introduce `media_path` helper and absolute-path `setSource` loading with sample video fallback
- Document Steam Deck quick start and multimedia troubleshooting steps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bbd54570f883308e58053b1c423c93